### PR TITLE
Added multi encoding fn for json and transit json

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,16 @@
-(defproject kixi/kixi.nybling "0.1.9-SNAPSHOT"
+(defproject kixi/kixi.nybling "0.1.11-SNAPSHOT"
   :description "A tiny library that converts formats"
   :url "http://github.com/mastodonc/kixi.nybling"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [cheshire "5.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]                 
                  [com.taoensso/nippy "2.13.0"]
-                 [kixi/kixi.log "0.1.4" :exclusions [cheshire]]]
+                 [kixi/kixi.log "0.1.4" :exclusions [cheshire]]
+                 [com.amazonaws/aws-lambda-java-core "1.0.0"]
+                 [com.amazonaws/aws-lambda-java-events "1.0.0"]
+                 ;update these in nybling namespace if upgrade
+                 [com.cognitect/transit-clj "0.8.300"]
+                 [cheshire "5.7.0"]]
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}}
   :repositories [["releases" {:url "https://clojars.org/repo"

--- a/src/kixi/nybling.clj
+++ b/src/kixi/nybling.clj
@@ -1,15 +1,26 @@
 (ns kixi.nybling
   (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [cheshire.core :as json]
             [cheshire.generate :refer [add-encoder encode-map]]
+            [cognitect.transit :as transit]
             [taoensso.nippy :as nippy]
             [kixi.log.timbre.appenders.logstash :refer [exception->map]])
-  (:import (com.fasterxml.jackson.core JsonGenerator JsonGenerationException))
+  (:import (com.fasterxml.jackson.core JsonGenerator JsonGenerationException)
+           (com.amazonaws.services.lambda.runtime.events 
+            KinesisEvent
+            KinesisEvent$KinesisEventRecord
+            KinesisEvent$Record)
+           (java.io ByteArrayOutputStream)
+           (com.fasterxml.jackson.core JsonGenerator))
 
   (:gen-class
    :name kixi.nybling
    :methods [#^{:static true} [ednStringToJsonString [java.lang.String] java.lang.String]
-             #^{:static true} [nippyByteArrayToJsonString [bytes] java.lang.String]]))
+             #^{:static true} [nippyByteArrayToJsonString [bytes] java.lang.String]
+             #^{:static true} [kinesisEventRecordToJsonVersions [com.amazonaws.services.lambda.runtime.events.KinesisEvent$KinesisEventRecord] java.util.List]]))
+
+(def project-definition (some-> (io/resource "project.clj") slurp edn/read-string))
 
 (add-encoder java.lang.Throwable
              (fn encode-throwable
@@ -23,12 +34,12 @@
 
 (add-encoder clojure.lang.ExceptionInfo
              (fn encode-exception-info
-               [exi jg]
+               [exi ^JsonGenerator jg]
                (.writeString jg (str exi))))
 
 (add-encoder java.util.regex.Pattern
              (fn encode-regex
-               [rp jg]
+               [rp ^JsonGenerator jg]
                (.writeString jg (str "##" rp))))
 
 (defn edn-str-to-json-str
@@ -48,3 +59,35 @@
 (defn -nippyByteArrayToJsonString
   [e]
   (nippy-byte-array-to-json-str e))
+
+(defn- clj->transit
+  ([m]
+   (clj->transit m :json))
+  ([m t]
+   (let [out (ByteArrayOutputStream. 4096)
+         writer (transit/writer out t)]
+     (transit/write writer m)
+     (.toString out))))
+
+(defn- wrap-event-with-meta
+  [^KinesisEvent$Record record
+   our-event]
+  {:event our-event
+   :partition-key (.getPartitionKey record)
+   :sequence-num (.getSequenceNumber record)
+   :dependency-versions {:transit "0.8.300"
+                         :cheshire "5.7.0"}})
+
+(defn kinesis-event-record->json-versions
+  [^KinesisEvent$KinesisEventRecord kinesis-event-record]
+  (let [^KinesisEvent$Record record (.getKinesis kinesis-event-record)
+        our-event (nippy/thaw (.array (.getData record)))
+        json-for-elastic-search (json/generate-string our-event)
+        meta-wrapped-event (wrap-event-with-meta record our-event)
+        transit-json-for-S3 (clj->transit meta-wrapped-event)]
+    (list json-for-elastic-search
+          transit-json-for-S3)))
+
+(defn -kinesisEventRecordToJsonVersions
+  [^KinesisEvent$KinesisEventRecord kinesis-event-record]
+  (kinesis-event-record->json-versions kinesis-event-record))


### PR DESCRIPTION
New function works with the KinesisEventRecord instance to create two
json encoded strings. The first is plain json, for routing to
ElasticSearch. The second is transit encoded and wraps the event in a
map containing partition key and other metadata. Both are returned in
a list.