### PR TITLE
Adding Baldr encoding for our events

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,13 +3,12 @@
   :url "http://github.com/mastodonc/kixi.nybling"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]                 
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [baldr "0.1.1"]
                  [com.taoensso/nippy "2.13.0"]
                  [kixi/kixi.log "0.1.4" :exclusions [cheshire]]
                  [com.amazonaws/aws-lambda-java-core "1.0.0"]
                  [com.amazonaws/aws-lambda-java-events "1.0.0"]
-                 ;update these in nybling namespace if upgrade
-                 [com.cognitect/transit-clj "0.8.300"]
                  [cheshire "5.7.0"]]
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}}


### PR DESCRIPTION
There are now two Java exposed fns.

One to create JSON, via cheshire, this uses nippy/thaw to optain the
event and then serialises into JSON.

The other wraps the raw event bytearray with metadata from the Kinesis
Record, endcodes the resulting map with nippy/freeze, and creates a
Baldr formatted (size hedaer) byte array.